### PR TITLE
[FEAT] 로그아웃 API 구현

### DIFF
--- a/src/main/java/org/tukcapstone/jetsetgo/domain/auth/dto/AuthRequest.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/domain/auth/dto/AuthRequest.java
@@ -26,6 +26,15 @@ public abstract class AuthRequest {
     public static class RefreshTokenRequest{
         @NotBlank(message = "AccessToken은 필수 입력 값입니다.")
         private String refreshToken;
-
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LogoutRequest{
+        @NotBlank(message = "AccessToken은 필수 입력 값입니다.")
+        private String refreshToken;
+    }
+
+
 }

--- a/src/main/java/org/tukcapstone/jetsetgo/domain/auth/service/AuthService.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/domain/auth/service/AuthService.java
@@ -1,9 +1,11 @@
 package org.tukcapstone.jetsetgo.domain.auth.service;
 
 import org.tukcapstone.jetsetgo.domain.auth.dto.AuthResponse;
+import org.tukcapstone.jetsetgo.domain.user.entity.User;
 import org.tukcapstone.jetsetgo.domain.user.entity.enums.SocialType;
 
 public interface AuthService {
     AuthResponse.LoginResponse login(SocialType provider, String accessToken);
     AuthResponse.LoginResponse refresh(String refreshToken);
+    void logout(User user, String accessToken, String refreshToken);
 }

--- a/src/main/java/org/tukcapstone/jetsetgo/global/response/result/code/UserResultCode.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/global/response/result/code/UserResultCode.java
@@ -11,6 +11,7 @@ public enum UserResultCode implements ResultCode {
     LOGIN(200, "SM001", "성공적으로 로그인하였습니다."),
     USER_INFO(200, "SM002", "회원 정보를 성공적으로 조회하였습니다."),
     REFRESH(200, "SM003", "성공적으로 로그인하였습니다."),
+    LOGOUT(200, "SM004", "성공적으로 로그아웃하였습니다."),
     ;
     private final int status;
     private final String code;

--- a/src/main/java/org/tukcapstone/jetsetgo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/global/security/JwtAuthenticationFilter.java
@@ -8,33 +8,35 @@ import java.io.IOException;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.tukcapstone.jetsetgo.domain.user.service.UserService;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.tukcapstone.jetsetgo.global.security.JwtAuthenticationToken;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserService userService;
+
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         String authHeader = request.getHeader("Authorization");
-        if(authHeader != null && authHeader.startsWith("Bearer ")){
-            String token = authHeader.substring(7);
-            if(jwtTokenProvider.isValidateToken(token)){
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7).trim();
+            if (jwtTokenProvider.isValidateToken(token)) {
                 Long userId = jwtTokenProvider.getId(token);
-                userService.findUserById(userId).ifPresent(user ->{
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
+                userService.findUserById(userId).ifPresent(user -> {
+                    JwtAuthenticationToken authentication =
+                            new JwtAuthenticationToken(user, null, Collections.emptyList(), token);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 });
-            }else{
+            } else {
                 log.warn("Invalid JWT token : {}", token);
             }
         }

--- a/src/main/java/org/tukcapstone/jetsetgo/global/security/JwtAuthenticationToken.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/global/security/JwtAuthenticationToken.java
@@ -1,0 +1,22 @@
+package org.tukcapstone.jetsetgo.global.security;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class JwtAuthenticationToken extends UsernamePasswordAuthenticationToken {
+    private final String token;
+
+    public JwtAuthenticationToken(Object principal, Object credentials, String token) {
+        super(principal, credentials);
+        this.token = token;
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+                                  Collection<? extends GrantedAuthority> authorities, String token) {
+        super(principal, credentials, authorities);
+        this.token = token;
+    }
+}

--- a/src/main/java/org/tukcapstone/jetsetgo/global/security/token/RedisTokenBlacklistProvider.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/global/security/token/RedisTokenBlacklistProvider.java
@@ -1,0 +1,25 @@
+package org.tukcapstone.jetsetgo.global.security.token;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisTokenBlacklistProvider implements TokenBlacklistProvider {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void blacklistToken(String token, long expiryTimeMillis) {
+        String redisKey = "accessToken:" + token;
+        redisTemplate.opsForValue().set(redisKey, "blacklisted", expiryTimeMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean isTokenBlacklisted(String token) {
+        String redisKey = "accessToken:" + token;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(redisKey));
+    }
+}

--- a/src/main/java/org/tukcapstone/jetsetgo/global/security/token/TokenBlacklistProvider.java
+++ b/src/main/java/org/tukcapstone/jetsetgo/global/security/token/TokenBlacklistProvider.java
@@ -1,0 +1,7 @@
+package org.tukcapstone.jetsetgo.global.security.token;
+
+
+public interface TokenBlacklistProvider {
+    void blacklistToken(String token, long expiryTimeMillis);
+    boolean isTokenBlacklisted(String token);
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#20 

## 📝 작업 내용
1. 로그아웃 구현
    - 로그아웃시 refreshToken 즉시 삭제처리, accessToken 블랙리스트에 추가
2. JwtAuthenticationFilter에 블랙리스트 된 토큰인지 인증 추가
## 💭 주의 사항
- 기존 인증 방식은 변하지 않고, 인증은 Filter에서 처리하기 때문에 인증 페이지 구현시 따로 고려할 요소가 없습니다.
- 로그아웃은 무조건 일어나야 하는 것 이므로, 만약 예외가 발생하면 로깅만 하고, 로그아웃이 처리된 것 처럼 수정했습니다.

## 💡 리뷰 포인트
